### PR TITLE
feat: add general issue template for reporting non-bug issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.yml
+++ b/.github/ISSUE_TEMPLATE/general.yml
@@ -1,0 +1,58 @@
+name: General Issue
+description: Report a general issue that is not a bug or feature request
+title: "[GENERAL]: "
+labels: ["triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this general issue report!
+        
+        This template is for issues that don't fit into the bug report or feature request categories.
+
+  - type: dropdown
+    id: issue-type
+    attributes:
+      label: Issue Type
+      description: What kind of issue are you reporting?
+      options:
+        - Documentation
+        - Question
+        - Performance
+        - Configuration
+        - Security
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide a clear and concise description of the issue.
+      placeholder: I need help understanding...
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the issue here.
+      placeholder: I'm trying to accomplish...
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: If you have any ideas on how to address this issue, please share them.
+      placeholder: I think this could be solved by...
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our contributing guidelines.
+      options:
+        - label: I agree to follow the project's Code of Conduct
+          required: true


### PR DESCRIPTION
---
name: Add general issue template.
---

## Description
This pull request adds a new issue template for general issues that don't fall under bug reports or feature requests. The template includes fields to categorize the issue, describe it, provide additional context, propose solutions, and agree to the project's Code of Conduct.

### New issue template:

* [`.github/ISSUE_TEMPLATE/general.yml`](diffhunk://#diff-5d6bb27ae8f2c28be67441894a16515e7dc6163ca551d4b4f4c3a58b39b5145eR1-R58): Introduced a "General Issue" template with dropdown options for issue type, text areas for description, context, and proposed solutions, and a checkbox for agreeing to the Code of Conduct.

## Checklist
- [x] My code follows the project's coding style
- [x] I have performed a self-review of my code
- [x] I have added tests where necessary
- [x] I have updated documentation where necessary

